### PR TITLE
Changing bit width of SAML11 DAUTHSTATUS.NSID and .NSNID fields to 2

### DIFF
--- a/Microchip/SAML11_DFP/4.3.139/svd/ATSAML11D14A.svd
+++ b/Microchip/SAML11_DFP/4.3.139/svd/ATSAML11D14A.svd
@@ -22209,7 +22209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   <field>
                      <name>NSID</name>
                      <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
+                     <bitWidth>2</bitWidth>
                      <enumeratedValues>
                         <name>NSIDSelect</name>
                         <enumeratedValue>
@@ -22227,7 +22227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   <field>
                      <name>NSNID</name>
                      <bitOffset>2</bitOffset>
-                     <bitWidth>1</bitWidth>
+                     <bitWidth>2</bitWidth>
                      <enumeratedValues>
                         <name>NSNIDSelect</name>
                         <enumeratedValue>

--- a/Microchip/SAML11_DFP/4.3.139/svd/ATSAML11D15A.svd
+++ b/Microchip/SAML11_DFP/4.3.139/svd/ATSAML11D15A.svd
@@ -22209,7 +22209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   <field>
                      <name>NSID</name>
                      <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
+                     <bitWidth>2</bitWidth>
                      <enumeratedValues>
                         <name>NSIDSelect</name>
                         <enumeratedValue>
@@ -22227,7 +22227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   <field>
                      <name>NSNID</name>
                      <bitOffset>2</bitOffset>
-                     <bitWidth>1</bitWidth>
+                     <bitWidth>2</bitWidth>
                      <enumeratedValues>
                         <name>NSNIDSelect</name>
                         <enumeratedValue>

--- a/Microchip/SAML11_DFP/4.3.139/svd/ATSAML11D16A.svd
+++ b/Microchip/SAML11_DFP/4.3.139/svd/ATSAML11D16A.svd
@@ -22209,7 +22209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   <field>
                      <name>NSID</name>
                      <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
+                     <bitWidth>2</bitWidth>
                      <enumeratedValues>
                         <name>NSIDSelect</name>
                         <enumeratedValue>
@@ -22227,7 +22227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   <field>
                      <name>NSNID</name>
                      <bitOffset>2</bitOffset>
-                     <bitWidth>1</bitWidth>
+                     <bitWidth>2</bitWidth>
                      <enumeratedValues>
                         <name>NSNIDSelect</name>
                         <enumeratedValue>

--- a/Microchip/SAML11_DFP/4.3.139/svd/ATSAML11E14A.svd
+++ b/Microchip/SAML11_DFP/4.3.139/svd/ATSAML11E14A.svd
@@ -22359,7 +22359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   <field>
                      <name>NSID</name>
                      <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
+                     <bitWidth>2</bitWidth>
                      <enumeratedValues>
                         <name>NSIDSelect</name>
                         <enumeratedValue>
@@ -22377,7 +22377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   <field>
                      <name>NSNID</name>
                      <bitOffset>2</bitOffset>
-                     <bitWidth>1</bitWidth>
+                     <bitWidth>2</bitWidth>
                      <enumeratedValues>
                         <name>NSNIDSelect</name>
                         <enumeratedValue>

--- a/Microchip/SAML11_DFP/4.3.139/svd/ATSAML11E15A.svd
+++ b/Microchip/SAML11_DFP/4.3.139/svd/ATSAML11E15A.svd
@@ -22359,7 +22359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   <field>
                      <name>NSID</name>
                      <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
+                     <bitWidth>2</bitWidth>
                      <enumeratedValues>
                         <name>NSIDSelect</name>
                         <enumeratedValue>
@@ -22377,7 +22377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   <field>
                      <name>NSNID</name>
                      <bitOffset>2</bitOffset>
-                     <bitWidth>1</bitWidth>
+                     <bitWidth>2</bitWidth>
                      <enumeratedValues>
                         <name>NSNIDSelect</name>
                         <enumeratedValue>

--- a/Microchip/SAML11_DFP/4.3.139/svd/ATSAML11E16A.svd
+++ b/Microchip/SAML11_DFP/4.3.139/svd/ATSAML11E16A.svd
@@ -22359,7 +22359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   <field>
                      <name>NSID</name>
                      <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
+                     <bitWidth>2</bitWidth>
                      <enumeratedValues>
                         <name>NSIDSelect</name>
                         <enumeratedValue>
@@ -22377,7 +22377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   <field>
                      <name>NSNID</name>
                      <bitOffset>2</bitOffset>
-                     <bitWidth>1</bitWidth>
+                     <bitWidth>2</bitWidth>
                      <enumeratedValues>
                         <name>NSNIDSelect</name>
                         <enumeratedValue>


### PR DESCRIPTION
I noticed while trying to run [`svd2rust`](https://docs.rs/svd2rust/latest/svd2rust/) on one of the ATSAML11 SVD files that the operation failed with the following message:
```
[INFO  svd2rust] Parsing device from SVD file
[ERROR svd2rust] Error parsing SVD XML file
    
    Caused by:
        0: In device `ATSAML11E14A`
        1: In peripheral `DIB`
        2: In register `DAUTHSTATUS`
        3: Parsing field `NSID` at 19898:19
        4: `EnumeratedValue error: Value 2 out of range 0..2
```

All 6 of the ATSAML11 SVD files appear to have an issue with the NSID and NSNID fields of the DAUTHSTATUS register, in that they set enumerated values of 2 and 3 for a field that is stated to be only 1 bit wide.

I looked at [`core_cm23.h`](https://github.com/Microchip-MPLAB-Harmony/dev_packs/blob/master/arm/CMSIS/5.8.0/CMSIS/Core/Include/core_cm23.h) and that file confirms that these fields should actually be 2 bits wide:
```
#define DIB_DAUTHSTATUS_NSNID_Pos           2U                                            /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Position */
#define DIB_DAUTHSTATUS_NSNID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSNID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Mask */

#define DIB_DAUTHSTATUS_NSID_Pos            0U                                            /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Position */
#define DIB_DAUTHSTATUS_NSID_Msk           (0x3UL /*<< DIB_DAUTHSTATUS_NSID_Pos*/)        /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Mask */
```

I fixed the issue in these fields and `svd2rust` runs successfully now. I haven't attempted to determine whether a similar issue may exist elsewhere.